### PR TITLE
docs: record v1.8.2 beta publication evidence

### DIFF
--- a/docs/releases/v1.8.2-beta.0-test-notes.md
+++ b/docs/releases/v1.8.2-beta.0-test-notes.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-Release candidate preparation began on 2026-08-31. This document does not mark
-the beta as published: the beta promotion PR, exact-commit workflow checks,
-independent review, tag, multi-platform image, and post-publication smoke remain
-required.
+Rackpad `v1.8.2-beta.0` was published as a GitHub prerelease on 2026-09-01.
+The annotated tag, successful `beta` branch head, and release workflow all
+resolve to `25f5cc2caef7769b1b7d470564a9ccbdf3ef0597`. The published immutable
+container and the moving `beta` container are multi-platform images for AMD64
+and ARM64 with provenance and SBOM attestations.
 
 Rack Studio remains opt-in and the classic rack elevation remains the default.
 Docker remains the recommended deployment. The experimental native Proxmox LXC
@@ -59,14 +60,44 @@ assets from `v1.8.1-beta.2` are retained without expanding their support status.
   links, and layouts. The untouched schema-45 source then reopened successfully
   under `v1.8.1-beta.2`, proving the rollback procedure.
 
-## Required before tag
+## Publication verification
 
-- Obtain independent review for authorization, schema initialization,
-  backup/restore, and cable mutations.
-- Pass the promotion PR's exact-head quality, Docker, CodeQL, security, and
-  PowerShell parsing checks, then merge through the PR to `beta`.
-- Verify the exact `beta` head and moving beta image, then obtain separate
-  authorization before creating or pushing `v1.8.2-beta.0`.
+- Promotion PR [#143](https://github.com/Kobii-git/rackpad/pull/143) passed its
+  exact-head quality, Docker, CodeQL, Trivy filesystem/image, security, and
+  PowerShell checks before merging through review to `beta`.
+- The [`beta` branch workflow](https://github.com/Kobii-git/rackpad/actions/runs/33443554109)
+  passed at the release commit and published the moving `beta` image before the
+  tag was authorized.
+- The [`v1.8.2-beta.0` release workflow](https://github.com/Kobii-git/rackpad/actions/runs/33463479010)
+  passed full repository validation, release-contract validation, AMD64/ARM64
+  image publication, and prerelease creation. The resulting
+  [GitHub release](https://github.com/Kobii-git/rackpad/releases/tag/v1.8.2-beta.0)
+  is marked as a prerelease.
+- Immutable image `ghcr.io/kobii-git/rackpad:1.8.2-beta.0` resolves to index
+  digest `sha256:55297f70dede48b3256c17bdace05501ee546a9ae1c2b561fcc61eb3ec0a78e8`,
+  with AMD64 manifest
+  `sha256:31c86e0eadf41b239037a13db68d94ccceccca6337922b407c18e1c98dd38306`
+  and ARM64 manifest
+  `sha256:5806370d63ec347925d6dc7730b3f112aa95e5a93e1cbddf6e83e6b7139e2fcc`.
+- Moving image `ghcr.io/kobii-git/rackpad:beta` resolves to index digest
+  `sha256:7c9b0cae8a191aa76d47ca410989c5a26e152270575e13500769e8dc8ab7c65f`,
+  with AMD64 manifest
+  `sha256:5a5a0c4b8719caf683c5ecb03390c9282581c520d4edec8a01e48491faf3adbf`
+  and ARM64 manifest
+  `sha256:0f1715d0c330633cf1146615e1a99880005e488e8642e19c35ae48d551533a92`.
+- A fresh disposable ARM64 volume using the immutable image passed health,
+  bootstrap, login, SPA navigation and version reporting, Studio Beta
+  activation, exact-port patching, SVG export, Physical Visualizer rendering,
+  restart persistence, schema-48 integrity, and foreign-key validation. The
+  demo contained 48 devices and 48 persisted physical layouts; the export was
+  33,538 bytes and 25 physical nodes rendered without browser errors.
+- A second disposable test upgraded a populated `v1.8.1-beta.2` schema-45
+  volume with the immutable image. All 47 pre-existing application tables and
+  458 pre-existing columns produced identical before/after SHA-256 content
+  hashes, with no mismatched tables. Counts remained 48 devices, 238 ports,
+  39 links, and 3 racks, while 48 physical layouts were added. Integrity and
+  foreign-key checks passed, and the untouched source reopened and authenticated
+  successfully with the old image for rollback verification.
 
 ## Compatibility and rollback
 


### PR DESCRIPTION
## Summary

- mark v1.8.2-beta.0 as published at the reviewed beta commit
- record release and beta workflow links plus immutable/moving image digests
- record fresh-volume runtime, exact-port patching, export, Visualizer, restart, upgrade, integrity, and rollback evidence

## Validation

- npm run check:docs
- git diff --check
- immutable ARM64 runtime smoke against ghcr.io/kobii-git/rackpad:1.8.2-beta.0
- schema 45 to 48 content comparison across 47 prior tables and 458 prior columns

This PR contains documentation only and targets beta.