### PR TITLE
Fix dual-face patch-panel authoring for v1.8.2-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ Rackpad uses semantic versioning and Git tags in the form `vX.Y.Z`.
 
 > On the `dev` branch; not yet tagged/released.
 
+## [1.8.2-beta.3] - 2026-09-04
+
+> Patch-panel authoring tester candidate. Existing hardware templates and device
+> layout snapshots remain unchanged until an administrator edits or applies a
+> template.
+
+### Changed
+
+- Patch-panel hardware starters now show matching 24-port front and rear blocks
+  with distinct face-qualified block, group, and slot identities.
+- Port-block editing now targets a block by name and face, so updating a rear
+  block preserves a same-named front block and upgrades only matching legacy
+  slots on the selected face.
+- Patch-panel pass-through discovery now follows cycle-safe custom device-type
+  lineage and pairs matching faces by normalized port name and connector kind.
+- The builder action is labelled **Add or update port block**, and patch-panel
+  starter previews show both faces before the template is saved.
+
+### Fixed
+
+- Applying the built-in 24-port patch-panel port template with its matching
+  hardware starter now maps all 48 front/rear ports without unmapped slots and
+  retains 24 pass-through pairs.
+
+### Test notes
+
+- Verify front and rear blocks can be added or updated independently, including
+  editing a legacy unqualified block without rewriting unrelated saved layouts.
+- Verify a custom descendant of `patch_panel` receives idempotent front/rear
+  pass-through normalization and that tracing matches names case-insensitively
+  with surrounding whitespace ignored.
+- Verify the 24-port starter renders 24 connectors on each face and applies with
+  48 bindings, zero unmapped slots, and 24 pass-through pairs.
+- No database migration is included; the schema remains at version 49. Rollback
+  to `v1.8.2-beta.2` does not require restoring a database backup.
+
 ## [1.8.2-beta.2] - 2026-09-03
 
 > Combined tester candidate for Proxmox native startup, inherited hardware

--- a/docs/RACK_STUDIO_DESIGN.md
+++ b/docs/RACK_STUDIO_DESIGN.md
@@ -79,7 +79,7 @@ Add authenticated APIs for listing templates and lab-scoped physical layouts.
 ### Phase 2 — Hardware Template Builder and exact device configurations
 
 - Add the visual Hardware Template Builder under Device Types.
-- Provide original parameterized starting families: generic 1U/2U/4U servers, desktop/tower PCs, storage equipment, firewalls, routers, 8/16/24/48-port switches, patch panels, PDUs, UPS units, KVMs, shelves, and blanking panels.
+- Provide original parameterized starting families: generic 1U/2U/4U servers, desktop/tower PCs, storage equipment, firewalls, routers, 8/16/24/48-port switches, patch panels with matching face-qualified front/rear blocks, PDUs, UPS units, KVMs, shelves, and blanking panels.
 - Provide original module primitives for NIC blocks, PCIe adapters, PSUs, fans, drive bays, management ports, console, USB, serial, VGA, SFP/SFP+/QSFP, and other physical connectors.
 - Allow users to generate port blocks by count, rows, columns, starting number, numbering direction, and connector kind, then click or drag ports into exact positions.
 - Support left-to-right, right-to-left, vertical, and serpentine port sequencing plus separate uplink blocks.

--- a/docs/releases/v1.8.2-beta.3-test-notes.md
+++ b/docs/releases/v1.8.2-beta.3-test-notes.md
@@ -1,0 +1,64 @@
+# Rackpad v1.8.2-beta.3 release test notes
+
+## Status
+
+Rackpad `v1.8.2-beta.3` is the dual-face patch-panel authoring candidate for
+issues #148 and #139. It must not be tagged or published until the exact pull
+request head and resulting `beta` merge commit pass the complete automated
+release gate. Publish it as an experimental prerelease and keep both issues open
+until Rack Studio testers confirm the four product behaviors below.
+
+This candidate does not change the database schema. Existing hardware templates
+and device-owned layout snapshots remain byte-for-byte stored as they are; no
+startup or migration path rewrites them. Editing a legacy block upgrades only
+the matching block and slots on the selected face. A rollback to
+`v1.8.2-beta.2` therefore does not require a database restore.
+
+## Candidate changes
+
+- Generate matching front and rear blocks numbered 1 through 24 in the
+  patch-panel starter, with distinct face-qualified block, group, and slot IDs.
+- Identify authored port blocks by normalized block ID and face, preserving a
+  same-named block on the other face during add or update.
+- Pair front/rear pass-through ports by normalized name and connector kind in
+  Rack Cabling and Visualizer tracing.
+- Recognize custom device types whose cycle-safe lineage includes
+  `patch_panel` during startup and logical-backup restore normalization.
+- Show both faces in the patch-panel starter preview and label the builder
+  action **Add or update port block**.
+
+## Automated acceptance
+
+- Run `npm run check:full` and `npm run screenshots:check` on the exact
+  candidate, inspect every result, and require the repository quality, CodeQL,
+  security, container, release-contract, ShellCheck, browser, and screenshot
+  gates on the exact `beta` merge commit before tagging.
+- Confirm builder unit coverage for face-qualified starter identities,
+  independent front/rear replacement, and selected-face legacy upgrades.
+- Confirm the built-in 24-port patch port template and matching hardware
+  template apply with 48 bindings, zero unmapped slots, 24 ports per face, and
+  accurate layout status.
+- Confirm a custom child of `patch_panel` receives the missing opposite-face
+  port once, retains matching names and kinds, and is idempotent on subsequent
+  normalization runs.
+- Confirm browser coverage authors the starter through Device Types, applies it
+  through Device Detail, and renders exactly 24 connectors on each face.
+
+## Tester confirmation for #139 and #148
+
+Keep #139 and #148 open until testers explicitly confirm all four behaviors:
+
+1. The patch-panel starter shows separate front and rear 24-port faces.
+2. Adding or updating a rear block does not replace its same-named front block.
+3. The built-in port and hardware templates apply with no unmapped slots.
+4. Cabling and Visualizer trace through all 24 matching front/rear pairs,
+   including a custom device type descended from `patch_panel`.
+
+## Publication and promotion
+
+The pull request must target `beta`. Tag only its resulting merge commit as
+`v1.8.2-beta.3`, publish a GitHub prerelease plus immutable and moving-beta
+container images, then request the confirmation above on #139. Close #148 and
+#139 only after that evidence is recorded. Promotion of the 1.8.2 line to
+`main` remains gated by successful beta.2/beta.3 product testing and the full
+real-Proxmox guest matrix and soak described for issue #138.

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -4231,6 +4231,127 @@ test("unmanaged status is selectable, bulk editable, filterable, and reported", 
   }
 });
 
+test("patch-panel hardware templates author, apply, and render both faces", async ({
+  page,
+  request,
+}) => {
+  const suffix = Date.now().toString(36);
+  const templateId = `e2e-patch-panel-${suffix}`;
+  const hostname = `patch-panel-${suffix}`;
+  const headers = { Authorization: `Bearer ${token}` };
+  let deviceId = "";
+
+  try {
+    await authenticate(page);
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.goto("/admin/device-types");
+    await page
+      .getByTestId("device-type-section-built-in")
+      .getByRole("button")
+      .filter({ hasText: "patch_panel" })
+      .click();
+
+    const builder = page.getByTestId("hardware-template-builder");
+    await builder
+      .getByTestId("hardware-template-starter")
+      .selectOption("patch-panel");
+    const frontPreview = builder.getByTestId("hardware-template-preview-front");
+    const rearPreview = builder.getByTestId("hardware-template-preview-rear");
+    await expect(frontPreview.locator('g[role="button"]')).toHaveCount(24);
+    await expect(rearPreview.locator('g[role="button"]')).toHaveCount(24);
+    await expect(
+      builder.getByRole("button", {
+        name: "Add or update port block",
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    await builder
+      .getByRole("textbox", { name: "ID", exact: true })
+      .first()
+      .fill(templateId);
+    await builder
+      .getByRole("textbox", { name: "Name", exact: true })
+      .fill(`E2E patch panel ${suffix}`);
+    const saveTemplateResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().endsWith("/api/hardware-templates"),
+    );
+    await builder
+      .getByRole("button", { name: "Save template", exact: true })
+      .click();
+    expect((await saveTemplateResponse).status()).toBe(201);
+    await expect(
+      builder.getByRole("combobox", { name: "Templates", exact: true }),
+    ).toHaveValue(templateId);
+
+    const deviceResponse = await request.post("/api/devices", {
+      headers,
+      data: {
+        labId: "lab_home",
+        hostname,
+        deviceType: "patch_panel",
+        status: "online",
+        placement: "room",
+        portTemplateId: "patch-panel-24",
+      },
+    });
+    expect(deviceResponse.status(), await deviceResponse.text()).toBe(201);
+    deviceId = ((await deviceResponse.json()) as { id: string }).id;
+
+    await page.goto(`/devices/${deviceId}?tab=physical`);
+    const templateSelect = page.getByRole("combobox", {
+      name: "Templates",
+      exact: true,
+    });
+    await expect(templateSelect).toContainText(`E2E patch panel ${suffix}`);
+    await templateSelect.selectOption(templateId);
+    await page.getByRole("button", { name: "Preview", exact: true }).click();
+    const frontFace = page.getByRole("img", {
+      name: "Front port layout",
+      exact: true,
+    });
+    const rearFace = page.getByRole("img", {
+      name: "Rear port layout",
+      exact: true,
+    });
+    await expect(frontFace.locator("g[aria-label]")).toHaveCount(24);
+    await expect(rearFace.locator("g[aria-label]")).toHaveCount(24);
+    await page.getByRole("button", { name: "Apply", exact: true }).click();
+
+    await expect
+      .poll(async () => {
+        const response = await request.get(
+          `/api/physical-layouts/${deviceId}`,
+          { headers },
+        );
+        if (!response.ok()) return null;
+        const layout = (await response.json()) as {
+          status: string;
+          sourceTemplateId: string;
+          bindings: Array<{ portId: string; slotId: string }>;
+          unmappedPortIds: string[];
+        };
+        return {
+          status: layout.status,
+          sourceTemplateId: layout.sourceTemplateId,
+          bindings: layout.bindings.length,
+          unmapped: layout.unmappedPortIds.length,
+        };
+      })
+      .toEqual({
+        status: "accurate",
+        sourceTemplateId: templateId,
+        bindings: 48,
+        unmapped: 0,
+      });
+  } finally {
+    if (deviceId) await request.delete(`/api/devices/${deviceId}`, { headers });
+    await request.delete(`/api/hardware-templates/${templateId}`, { headers });
+  }
+});
+
 test("Device Types workspace supports CRUD, usage, and admin-only access", async ({
   browser,
   page,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rackpad",
-  "version": "1.8.2-beta.2",
+  "version": "1.8.2-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rackpad",
-      "version": "1.8.2-beta.2",
+      "version": "1.8.2-beta.3",
       "dependencies": {
         "@fastify/cors": "^10.0.1",
         "@fastify/rate-limit": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rackpad",
-  "version": "1.8.2-beta.2",
+  "version": "1.8.2-beta.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/db.ts
+++ b/server/db.ts
@@ -1427,21 +1427,60 @@ type PatchPanelPortRow = {
   macAddress: string | null;
 };
 
+function patchPanelDeviceIdsFromStoredLineage() {
+  const parentById = new Map<string, string | null>();
+  const setting = db
+    .prepare("SELECT value FROM appSettings WHERE key = 'deviceTypes'")
+    .get() as { value?: string } | undefined;
+  if (setting?.value) {
+    try {
+      const custom = (JSON.parse(setting.value) as { custom?: unknown }).custom;
+      if (Array.isArray(custom)) {
+        for (const entry of custom) {
+          if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+            continue;
+          }
+          const record = entry as Record<string, unknown>;
+          if (typeof record.id !== "string") continue;
+          const id = record.id.trim().toLowerCase();
+          const parent =
+            typeof record.parentType === "string"
+              ? record.parentType.trim().toLowerCase()
+              : null;
+          if (id) parentById.set(id, parent || null);
+        }
+      }
+    } catch {
+      // Invalid settings are ignored by the device-type loader as well.
+    }
+  }
+
+  const includesPatchPanel = (deviceType: string) => {
+    const seen = new Set<string>();
+    let current = deviceType.trim().toLowerCase();
+    while (current && !seen.has(current)) {
+      if (current === "patch_panel") return true;
+      seen.add(current);
+      current = parentById.get(current) ?? "";
+    }
+    return false;
+  };
+
+  return (
+    db.prepare("SELECT id, deviceType FROM devices").all() as Array<{
+      id: string;
+      deviceType: string;
+    }>
+  )
+    .filter((row) => includesPatchPanel(row.deviceType))
+    .map((row) => row.id);
+}
+
 export function ensurePatchPanelPassThroughPorts(deviceIds?: string[]) {
   const targetDeviceIds =
     deviceIds && deviceIds.length > 0
       ? [...new Set(deviceIds)]
-      : (
-          db
-            .prepare(
-              `
-        SELECT id
-        FROM devices
-        WHERE deviceType = 'patch_panel'
-      `,
-            )
-            .all() as Array<{ id: string }>
-        ).map((row) => row.id);
+      : patchPanelDeviceIdsFromStoredLineage();
 
   if (targetDeviceIds.length === 0) return 0;
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -2445,7 +2445,12 @@ const restoreBackupSnapshot = db.transaction(
     }
     ensurePatchPanelPassThroughPorts(
       devices
-        .filter((row) => row.deviceType === "patch_panel")
+        .filter((row) =>
+          deviceTypeLineageFromParents(
+            String(row.deviceType ?? ""),
+            restoredDeviceTypeParents,
+          ).includes("patch_panel"),
+        )
         .map((row) => String(row.id)),
     );
     const portIds = new Set(ports.map((row) => String(row.id)));

--- a/server/tests/client-helpers.test.ts
+++ b/server/tests/client-helpers.test.ts
@@ -358,15 +358,15 @@ test("cabling map follows passive patch panel pairs to active endpoints", () => 
     makePort({
       id: "patch_front",
       deviceId: "patch_1",
-      name: "F1",
+      name: "Jack 1",
       position: 1,
       face: "front",
     }),
     makePort({
       id: "patch_rear",
       deviceId: "patch_1",
-      name: "R1",
-      position: 1,
+      name: "  jack 1  ",
+      position: 99,
       face: "rear",
     }),
     makePort({ id: "access_gi1", deviceId: "access_1", name: "Gi1" }),
@@ -402,14 +402,14 @@ test("cabling map full path includes passive hops", () => {
     makePort({
       id: "patch_2_front",
       deviceId: "patch_2",
-      name: "F1",
+      name: "1",
       position: 1,
       face: "front",
     }),
     makePort({
       id: "patch_2_rear",
       deviceId: "patch_2",
-      name: "R1",
+      name: "1",
       position: 1,
       face: "rear",
     }),
@@ -434,7 +434,7 @@ test("cabling map full path includes passive hops", () => {
 
   assert.match(
     text,
-    /server-2 eth1 --cable--> patch-2 F1 --passive--> patch-2 R1 --cable--> access-2 Gi1/,
+    /server-2 eth1 --cable--> patch-2 1 --passive--> patch-2 1 --cable--> access-2 Gi1/,
   );
 });
 
@@ -561,14 +561,14 @@ test("cabling map follows a bonded member through its physical patch path", () =
     makePort({
       id: "patch_front",
       deviceId: "lag_patch",
-      name: "F1",
+      name: "1",
       position: 1,
       face: "front",
     }),
     makePort({
       id: "patch_rear",
       deviceId: "lag_patch",
-      name: "R1",
+      name: "1",
       position: 1,
       face: "rear",
     }),
@@ -598,19 +598,21 @@ test("cabling map follows a bonded member through its physical patch path", () =
   };
 
   assert.equal(
-    buildCablingMapLines(input, "direct").find((line) => line.portId === "eth_1")
-      ?.text,
-    "lag-server eth1 -> lag-patch F1 (member of Bond1)",
+    buildCablingMapLines(input, "direct").find(
+      (line) => line.portId === "eth_1",
+    )?.text,
+    "lag-server eth1 -> lag-patch 1 (member of Bond1)",
   );
   assert.equal(
-    buildCablingMapLines(input, "active").find((line) => line.portId === "eth_1")
-      ?.text,
+    buildCablingMapLines(input, "active").find(
+      (line) => line.portId === "eth_1",
+    )?.text,
     "lag-server eth1 -> lag-switch Gi1 (member of Bond1)",
   );
   assert.equal(
     buildCablingMapLines(input, "full").find((line) => line.portId === "eth_1")
       ?.text,
-    "lag-server eth1 --cable--> lag-patch F1 --passive--> lag-patch R1 --cable--> lag-switch Gi1 (member of Bond1)",
+    "lag-server eth1 --cable--> lag-patch 1 --passive--> lag-patch 1 --cable--> lag-switch Gi1 (member of Bond1)",
   );
 });
 
@@ -634,14 +636,14 @@ test("cabling map stops loops instead of walking forever", () => {
     makePort({
       id: "loop_front",
       deviceId: "loop_patch",
-      name: "F1",
+      name: "1",
       position: 1,
       face: "front",
     }),
     makePort({
       id: "loop_rear",
       deviceId: "loop_patch",
-      name: "R1",
+      name: "1",
       position: 1,
       face: "rear",
     }),

--- a/server/tests/physical-layouts.test.ts
+++ b/server/tests/physical-layouts.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { after, afterEach, beforeEach, test } from "node:test";
 import Database from "better-sqlite3";
+import { createStarterTemplate } from "../../src/lib/hardware-template-builder.ts";
 
 const tempDir = mkdtempSync(
   path.join(os.tmpdir(), "rackpad-physical-layouts-"),
@@ -15,7 +16,8 @@ process.env.OIDC_ENABLED = "0";
 process.env.RACKPAD_SECRET_KEY = "rackpad-physical-layout-test-secret";
 
 const { createApp } = await import("../app.js");
-const { CURRENT_SCHEMA_VERSION, db } = await import("../db.js");
+const { CURRENT_SCHEMA_VERSION, db, ensurePatchPanelPassThroughPorts } =
+  await import("../db.js");
 const { setBootstrapState } = await import("../lib/auth.js");
 
 type AppInstance = Awaited<ReturnType<typeof createApp>>;
@@ -348,6 +350,127 @@ test("approved physical ports follow all existing canonical port positions", asy
       },
     ],
   );
+});
+
+test("24-port patch templates bind both faces without unmapped slots", async () => {
+  const adminToken = await bootstrapAdmin();
+  const customTypeResponse = await app.inject({
+    method: "POST",
+    url: "/api/device-types",
+    headers: authHeaders(adminToken),
+    payload: {
+      id: "keystone_patch",
+      label: "Keystone patch panel",
+      parentType: "patch_panel",
+    },
+  });
+  assert.equal(customTypeResponse.statusCode, 201, customTypeResponse.body);
+
+  const template = createStarterTemplate(
+    "patch-panel",
+    "keystone-patch-24",
+    "Keystone patch 24",
+  );
+  template.deviceTypes = ["keystone_patch"];
+  const createTemplateResponse = await app.inject({
+    method: "POST",
+    url: "/api/hardware-templates",
+    headers: authHeaders(adminToken),
+    payload: template,
+  });
+  assert.equal(
+    createTemplateResponse.statusCode,
+    201,
+    createTemplateResponse.body,
+  );
+
+  const deviceResponse = await app.inject({
+    method: "POST",
+    url: "/api/devices",
+    headers: authHeaders(adminToken),
+    payload: {
+      labId: "lab_home",
+      hostname: "keystone-patch-01",
+      deviceType: "keystone_patch",
+      status: "online",
+      placement: "room",
+      portTemplateId: "patch-panel-24",
+    },
+  });
+  assert.equal(deviceResponse.statusCode, 201, deviceResponse.body);
+  const device = json(deviceResponse) as { id: string };
+
+  const previewResponse = await app.inject({
+    method: "POST",
+    url: `/api/physical-layouts/${device.id}/preview`,
+    headers: authHeaders(adminToken),
+    payload: { templateId: template.id },
+  });
+  assert.equal(previewResponse.statusCode, 200, previewResponse.body);
+  const preview = json(previewResponse) as {
+    bindings: Array<{ portId: string; slotId: string }>;
+    unmappedPortIds: string[];
+    portsToCreate: Array<{ slotId: string }>;
+    snapshot: {
+      portSlots: Array<{ id: string; face: "front" | "rear" }>;
+    };
+  };
+  assert.equal(preview.bindings.length, 48);
+  assert.deepEqual(preview.unmappedPortIds, []);
+  assert.deepEqual(preview.portsToCreate, []);
+  assert.equal(
+    preview.snapshot.portSlots.filter((slot) => slot.face === "front").length,
+    24,
+  );
+  assert.equal(
+    preview.snapshot.portSlots.filter((slot) => slot.face === "rear").length,
+    24,
+  );
+
+  const applyResponse = await app.inject({
+    method: "POST",
+    url: `/api/physical-layouts/${device.id}/apply`,
+    headers: authHeaders(adminToken),
+    payload: preview,
+  });
+  assert.equal(applyResponse.statusCode, 200, applyResponse.body);
+  assert.equal(json(applyResponse).status, "accurate");
+  assert.equal(json(applyResponse).bindings.length, 48);
+});
+
+test("pass-through normalization includes custom patch-panel descendants", async () => {
+  const adminToken = await bootstrapAdmin();
+  const customTypeResponse = await app.inject({
+    method: "POST",
+    url: "/api/device-types",
+    headers: authHeaders(adminToken),
+    payload: {
+      id: "fiber_patch",
+      label: "Fiber patch panel",
+      parentType: "patch_panel",
+    },
+  });
+  assert.equal(customTypeResponse.statusCode, 201, customTypeResponse.body);
+  const device = await createDevice(
+    adminToken,
+    "fiber-patch-01",
+    "fiber_patch",
+  );
+  await createPort(adminToken, device.id, " LC 01 ", "front", "fiber");
+
+  assert.equal(ensurePatchPanelPassThroughPorts(), 1);
+  assert.deepEqual(
+    db
+      .prepare(
+        "SELECT name, kind, face FROM ports WHERE deviceId = ? ORDER BY face",
+      )
+      .all(device.id),
+    [
+      { name: "LC 01", kind: "fiber", face: "front" },
+      { name: "LC 01", kind: "fiber", face: "rear" },
+    ],
+  );
+  assert.equal(ensurePatchPanelPassThroughPorts(), 0);
 });
 
 test("original six-port templates retain exact slots after their source template is deleted", async () => {
@@ -1521,6 +1644,7 @@ function resetDatabase() {
     DELETE FROM racks;
     DELETE FROM rooms;
     DELETE FROM users;
+    DELETE FROM appSettings;
     DELETE FROM labs;
   `);
   setBootstrapState(null);

--- a/src/components/rack/HardwareTemplateBuilder.tsx
+++ b/src/components/rack/HardwareTemplateBuilder.tsx
@@ -361,6 +361,8 @@ export function HardwareTemplateBuilder({
   const selectedSlot = draft.portSlots.find(
     (slot) => slot.id === selectedSlotId,
   );
+  const previewFaces: RackFace[] =
+    draft.category === "patch_panel" ? ["front", "rear"] : [face];
   const bulkBlocked = bulkPreviews.some(
     (preview) =>
       preview.conflicts.length > 0 || preview.linkedUnmappedPortIds.length > 0,
@@ -406,6 +408,7 @@ export function HardwareTemplateBuilder({
             </Field>
             <Field label={t("Type")}>
               <select
+                data-testid="hardware-template-starter"
                 className="rk-control h-8 w-full px-2.5 text-sm"
                 value={starterId}
                 onChange={(event) => selectStarter(event.target.value)}
@@ -542,7 +545,8 @@ export function HardwareTemplateBuilder({
                 ) : null}
                 {inheritedDefaultSource ? (
                   <Badge tone="neutral">
-                    {t("Parent")}: {localizedDeviceTypeIdLabel(
+                    {t("Parent")}:{" "}
+                    {localizedDeviceTypeIdLabel(
                       inheritedDefaultSource,
                       deviceTypes,
                       t,
@@ -555,35 +559,60 @@ export function HardwareTemplateBuilder({
 
           <div className="min-w-0 space-y-4">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex gap-2">
-                {(["front", "rear"] as const).map((entry) => (
-                  <Button
-                    key={entry}
-                    size="sm"
-                    variant={face === entry ? "secondary" : "outline"}
-                    onClick={() => setFace(entry)}
-                  >
-                    {entry === "front" ? t("Front") : t("Rear")}
-                  </Button>
-                ))}
-              </div>
+              {draft.category === "patch_panel" ? (
+                <span className="text-xs font-medium text-[var(--text-muted)]">
+                  {t("Front")} + {t("Rear")}
+                </span>
+              ) : (
+                <div className="flex gap-2">
+                  {(["front", "rear"] as const).map((entry) => (
+                    <Button
+                      key={entry}
+                      size="sm"
+                      variant={face === entry ? "secondary" : "outline"}
+                      onClick={() => setFace(entry)}
+                    >
+                      {entry === "front" ? t("Front") : t("Rear")}
+                    </Button>
+                  ))}
+                </div>
+              )}
               <span className="flex items-center gap-1 text-xs text-[var(--text-muted)]">
                 <MousePointer2 className="size-3.5" />
                 {t("Position")}
               </span>
             </div>
-            <PhysicalPortSlotEditor
-              layout={draft}
-              face={face}
-              selectedSlotId={selectedSlotId}
-              onSelectSlot={setSelectedSlotId}
-              onMoveSlot={(slotId, x, y) =>
-                editable &&
-                setDraft((current) =>
-                  movePhysicalPortSlot(current, slotId, x, y),
-                )
+            <div
+              className={
+                previewFaces.length > 1 ? "grid gap-3 lg:grid-cols-2" : ""
               }
-            />
+            >
+              {previewFaces.map((previewFace) => (
+                <div
+                  key={previewFace}
+                  data-testid={`hardware-template-preview-${previewFace}`}
+                  className="min-w-0 space-y-2"
+                >
+                  {previewFaces.length > 1 && (
+                    <div className="rk-kicker">
+                      {previewFace === "front" ? t("Front") : t("Rear")}
+                    </div>
+                  )}
+                  <PhysicalPortSlotEditor
+                    layout={draft}
+                    face={previewFace}
+                    selectedSlotId={selectedSlotId}
+                    onSelectSlot={setSelectedSlotId}
+                    onMoveSlot={(slotId, x, y) =>
+                      editable &&
+                      setDraft((current) =>
+                        movePhysicalPortSlot(current, slotId, x, y),
+                      )
+                    }
+                  />
+                </div>
+              ))}
+            </div>
             {selectedSlot && (
               <div className="grid gap-2 rounded-[var(--radius-sm)] border border-[var(--border-default)] bg-[var(--surface-1)] p-3 sm:grid-cols-4">
                 <Field label={t("Port")}>
@@ -803,7 +832,7 @@ export function HardwareTemplateBuilder({
                 }}
               >
                 <Plus />
-                {t("Add port")}
+                {t("Add or update port block")}
               </Button>
             </section>
 

--- a/src/i18n/base.ts
+++ b/src/i18n/base.ts
@@ -347,6 +347,7 @@ export const en = {
   "Template name": "Template name",
   "Applies to": "Applies to",
   "Add port": "Add port",
+  "Add or update port block": "Add or update port block",
   "Add jack": "Add jack",
   "Create template": "Create template",
   "Save template": "Save template",

--- a/src/i18n/locales/af.ts
+++ b/src/i18n/locales/af.ts
@@ -349,6 +349,7 @@ export const af = {
   "Template name": "Sjabloonnaam",
   "Applies to": "Geld vir",
   "Add port": "Voeg poort by",
+  "Add or update port block": "Voeg poortblok by of werk dit op",
   "Add jack": "Voeg kontak by",
   "Create template": "Skep sjabloon",
   "Save template": "Stoor sjabloon",

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -349,6 +349,7 @@ export const ar = {
   "Template name": "اسم القالب",
   "Applies to": "ينطبق على",
   "Add port": "إضافة منفذ",
+  "Add or update port block": "إضافة كتلة منافذ أو تحديثها",
   "Add jack": "إضافة مقبس",
   "Create template": "إنشاء قالب",
   "Save template": "حفظ القالب",

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -349,6 +349,7 @@ export const bn = {
   "Template name": "টেমপ্লেটের নাম",
   "Applies to": "প্রযোজ্য",
   "Add port": "পোর্ট যোগ করুন",
+  "Add or update port block": "পোর্ট ব্লক যোগ বা আপডেট করুন",
   "Add jack": "জ্যাক যোগ করুন",
   "Create template": "টেমপ্লেট তৈরি করুন",
   "Save template": "টেমপ্লেট সংরক্ষণ করুন",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -349,6 +349,7 @@ export const de = {
   "Template name": "Vorlagenname",
   "Applies to": "Gilt für",
   "Add port": "Port hinzufügen",
+  "Add or update port block": "Portblock hinzufügen oder aktualisieren",
   "Add jack": "Buchse hinzufügen",
   "Create template": "Vorlage erstellen",
   "Save template": "Vorlage speichern",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -349,6 +349,7 @@ export const es = {
   "Template name": "Nombre de plantilla",
   "Applies to": "Se aplica a",
   "Add port": "Añadir puerto",
+  "Add or update port block": "Añadir o actualizar bloque de puertos",
   "Add jack": "Añadir toma",
   "Create template": "Crear plantilla",
   "Save template": "Guardar plantilla",

--- a/src/i18n/locales/fa.ts
+++ b/src/i18n/locales/fa.ts
@@ -349,6 +349,7 @@ export const fa = {
   "Template name": "نام قالب",
   "Applies to": "اعمال بر",
   "Add port": "افزودن پورت",
+  "Add or update port block": "افزودن یا به‌روزرسانی بلوک پورت",
   "Add jack": "افزودن جک",
   "Create template": "ایجاد قالب",
   "Save template": "ذخیره قالب",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -349,6 +349,7 @@ export const fr = {
   "Template name": "Nom du modèle",
   "Applies to": "S’applique à",
   "Add port": "Ajouter un port",
+  "Add or update port block": "Ajouter ou mettre à jour le bloc de ports",
   "Add jack": "Ajouter une prise",
   "Create template": "Créer le modèle",
   "Save template": "Enregistrer le modèle",

--- a/src/i18n/locales/he.ts
+++ b/src/i18n/locales/he.ts
@@ -349,6 +349,7 @@ export const he = {
   "Template name": "שם תבנית",
   "Applies to": "חל על",
   "Add port": "הוספת יציאה",
+  "Add or update port block": "הוספה או עדכון של בלוק יציאות",
   "Add jack": "הוספת שקע",
   "Create template": "יצירת תבנית",
   "Save template": "שמירת תבנית",

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -349,6 +349,7 @@ export const hi = {
   "Template name": "टेम्पलेट नाम",
   "Applies to": "लागू होता है",
   "Add port": "पोर्ट जोड़ें",
+  "Add or update port block": "पोर्ट ब्लॉक जोड़ें या अपडेट करें",
   "Add jack": "जैक जोड़ें",
   "Create template": "टेम्पलेट बनाएँ",
   "Save template": "टेम्पलेट सहेजें",

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -349,6 +349,7 @@ export const id = {
   "Template name": "Nama templat",
   "Applies to": "Berlaku untuk",
   "Add port": "Tambah port",
+  "Add or update port block": "Tambah atau perbarui blok port",
   "Add jack": "Tambah jack",
   "Create template": "Buat templat",
   "Save template": "Simpan templat",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -349,6 +349,7 @@ export const it = {
   "Template name": "Nome modello",
   "Applies to": "Si applica a",
   "Add port": "Aggiungi porta",
+  "Add or update port block": "Aggiungi o aggiorna blocco porte",
   "Add jack": "Aggiungi presa",
   "Create template": "Crea modello",
   "Save template": "Salva modello",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -349,6 +349,7 @@ export const ja = {
   "Template name": "テンプレート名",
   "Applies to": "適用対象",
   "Add port": "ポートを追加",
+  "Add or update port block": "ポートブロックを追加または更新",
   "Add jack": "ジャックを追加",
   "Create template": "テンプレートを作成",
   "Save template": "テンプレートを保存",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -349,6 +349,7 @@ export const ko = {
   "Template name": "템플릿 이름",
   "Applies to": "적용 대상",
   "Add port": "포트 추가",
+  "Add or update port block": "포트 블록 추가 또는 업데이트",
   "Add jack": "잭 추가",
   "Create template": "템플릿 만들기",
   "Save template": "템플릿 저장",

--- a/src/i18n/locales/nl.ts
+++ b/src/i18n/locales/nl.ts
@@ -349,6 +349,7 @@ export const nl = {
   "Template name": "Sjabloonnaam",
   "Applies to": "Van toepassing op",
   "Add port": "Poort toevoegen",
+  "Add or update port block": "Poortblok toevoegen of bijwerken",
   "Add jack": "Aansluiting toevoegen",
   "Create template": "Sjabloon aanmaken",
   "Save template": "Sjabloon opslaan",

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -349,6 +349,7 @@ export const pl = {
   "Template name": "Nazwa szablonu",
   "Applies to": "Dotyczy",
   "Add port": "Dodaj port",
+  "Add or update port block": "Dodaj lub zaktualizuj blok portów",
   "Add jack": "Dodaj gniazdo",
   "Create template": "Utwórz szablon",
   "Save template": "Zapisz szablon",

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -349,6 +349,7 @@ export const pt = {
   "Template name": "Nome do modelo",
   "Applies to": "Aplica-se a",
   "Add port": "Adicionar porta",
+  "Add or update port block": "Adicionar ou atualizar bloco de portas",
   "Add jack": "Adicionar tomada",
   "Create template": "Criar modelo",
   "Save template": "Guardar modelo",

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -349,6 +349,7 @@ export const ru = {
   "Template name": "Имя шаблона",
   "Applies to": "Применяется к",
   "Add port": "Добавить порт",
+  "Add or update port block": "Добавить или обновить блок портов",
   "Add jack": "Добавить розетку",
   "Create template": "Создать шаблон",
   "Save template": "Сохранить шаблон",

--- a/src/i18n/locales/th.ts
+++ b/src/i18n/locales/th.ts
@@ -349,6 +349,7 @@ export const th = {
   "Template name": "ชื่อเทมเพลต",
   "Applies to": "ใช้กับ",
   "Add port": "เพิ่มพอร์ต",
+  "Add or update port block": "เพิ่มหรืออัปเดตบล็อกพอร์ต",
   "Add jack": "เพิ่มแจ็ค",
   "Create template": "สร้างเทมเพลต",
   "Save template": "บันทึกเทมเพลต",

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -349,6 +349,7 @@ export const tr = {
   "Template name": "Şablon adı",
   "Applies to": "Uygulandığı",
   "Add port": "Port ekle",
+  "Add or update port block": "Bağlantı noktası bloğu ekle veya güncelle",
   "Add jack": "Jak ekle",
   "Create template": "Şablon oluştur",
   "Save template": "Şablonu kaydet",

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -349,6 +349,7 @@ export const uk = {
   "Template name": "Назва шаблону",
   "Applies to": "Застосовується до",
   "Add port": "Додати порт",
+  "Add or update port block": "Додати або оновити блок портів",
   "Add jack": "Додати розетку",
   "Create template": "Створити шаблон",
   "Save template": "Зберегти шаблон",

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -349,6 +349,7 @@ export const vi = {
   "Template name": "Tên mẫu",
   "Applies to": "Áp dụng cho",
   "Add port": "Thêm cổng",
+  "Add or update port block": "Thêm hoặc cập nhật khối cổng",
   "Add jack": "Thêm jack",
   "Create template": "Tạo mẫu",
   "Save template": "Lưu mẫu",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -349,6 +349,7 @@ export const zhTW = {
   "Template name": "範本名稱",
   "Applies to": "適用於",
   "Add port": "新增連接埠",
+  "Add or update port block": "新增或更新連接埠區塊",
   "Add jack": "新增接口",
   "Create template": "建立範本",
   "Save template": "儲存範本",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -349,6 +349,7 @@ export const zh = {
   "Template name": "模板名称",
   "Applies to": "适用于",
   "Add port": "添加端口",
+  "Add or update port block": "添加或更新端口块",
   "Add jack": "添加接口",
   "Create template": "创建模板",
   "Save template": "保存模板",

--- a/src/lib/cabling-map.ts
+++ b/src/lib/cabling-map.ts
@@ -245,25 +245,26 @@ function buildAdjacency(
   for (const device of input.devices) {
     if (!isPassiveDevice({ ...input, deviceById }, device.id)) continue;
     const ports = input.ports.filter((port) => port.deviceId === device.id);
-    const byPosition = new Map<number, Port[]>();
+    const byTermination = new Map<string, Port[]>();
     for (const port of ports) {
-      byPosition.set(port.position, [
-        ...(byPosition.get(port.position) ?? []),
+      const termination = `${port.kind}|${port.name.trim().toLowerCase()}`;
+      byTermination.set(termination, [
+        ...(byTermination.get(termination) ?? []),
         port,
       ]);
     }
-    for (const [position, pairPorts] of byPosition) {
+    for (const [termination, pairPorts] of byTermination) {
       const front = pairPorts.find((port) => port.face === "front");
       const rear = pairPorts.find((port) => port.face === "rear");
       if (!front || !rear) continue;
       add({
-        id: `passive:${device.id}:${position}:front`,
+        id: `passive:${device.id}:${termination}:front`,
         kind: "passive",
         fromPort: front,
         toPort: rear,
       });
       add({
-        id: `passive:${device.id}:${position}:rear`,
+        id: `passive:${device.id}:${termination}:rear`,
         kind: "passive",
         fromPort: rear,
         toPort: front,

--- a/src/lib/hardware-template-builder.test.ts
+++ b/src/lib/hardware-template-builder.test.ts
@@ -69,6 +69,107 @@ test("24-port switch starter keeps access ports separate from right-side 10G upl
   );
 });
 
+test("patch-panel starter produces matching face-qualified front and rear blocks", () => {
+  const template = createStarterTemplate(
+    "patch-panel",
+    "lab-patch",
+    "Lab patch panel",
+  );
+  const front = template.portSlots.filter((slot) => slot.face === "front");
+  const rear = template.portSlots.filter((slot) => slot.face === "rear");
+
+  assert.equal(front.length, 24);
+  assert.equal(rear.length, 24);
+  assert.deepEqual(
+    template.portBlueprints.map((block) => [block.id, block.face]),
+    [
+      ["ports:front", "front"],
+      ["ports:rear", "rear"],
+    ],
+  );
+  assert.deepEqual(
+    front.map((slot) => slot.label),
+    rear.map((slot) => slot.label),
+  );
+  assert.equal(new Set(template.portSlots.map((slot) => slot.id)).size, 48);
+  assert.deepEqual(
+    new Set(front.map((slot) => slot.groupId)),
+    new Set(["ports:front"]),
+  );
+  assert.deepEqual(
+    new Set(rear.map((slot) => slot.groupId)),
+    new Set(["ports:rear"]),
+  );
+});
+
+test("port-block replacement is face-aware and upgrades only the selected legacy face", () => {
+  const legacyFront: PortBlockDefinition = {
+    id: "ports",
+    face: "front",
+    connector: "rj45",
+    count: 2,
+    rows: 1,
+    columns: 2,
+    start: 1,
+    direction: "left-to-right",
+    x: 100,
+    y: 100,
+    width: 200,
+    height: 60,
+  };
+  const template = createStarterTemplate("server-1u", "legacy", "Legacy");
+  template.portBlueprints = [{ ...legacyFront }];
+  template.portSlots = generatePortBlock(legacyFront);
+
+  const withRear = replacePortBlock(template, {
+    ...legacyFront,
+    face: "rear",
+  });
+  assert.deepEqual(
+    withRear.portBlueprints.map((block) => [block.id, block.face]),
+    [
+      ["ports", "front"],
+      ["ports:rear", "rear"],
+    ],
+  );
+  assert.equal(
+    withRear.portSlots.filter((slot) => slot.groupId === "ports").length,
+    2,
+  );
+  assert.equal(
+    withRear.portSlots.filter((slot) => slot.groupId === "ports:rear").length,
+    2,
+  );
+
+  const updatedFront = replacePortBlock(withRear, {
+    ...legacyFront,
+    count: 3,
+    columns: 3,
+  });
+  assert.deepEqual(
+    updatedFront.portBlueprints.map((block) => [block.id, block.face]),
+    [
+      ["ports:rear", "rear"],
+      ["ports:front", "front"],
+    ],
+  );
+  assert.equal(
+    updatedFront.portSlots.filter((slot) => slot.groupId === "ports:front")
+      .length,
+    3,
+  );
+  assert.equal(
+    updatedFront.portSlots.filter((slot) => slot.groupId === "ports:rear")
+      .length,
+    2,
+  );
+  assert.equal(
+    updatedFront.portSlots.some((slot) => slot.groupId === "ports"),
+    false,
+  );
+  assert.equal(new Set(updatedFront.portSlots.map((slot) => slot.id)).size, 5);
+});
+
 test("server starters support independent module variants and exact device geometry edits", () => {
   const template = createStarterTemplate(
     "server-2u",
@@ -95,10 +196,13 @@ test("server starters support independent module variants and exact device geome
     width: 760,
     height: 60,
   });
-  const moved = movePhysicalPortSlot(withPorts, "six-nics-1", 90, 130);
-  assert.equal(moved.portSlots.find((slot) => slot.id === "six-nics-1")?.x, 90);
+  const moved = movePhysicalPortSlot(withPorts, "six-nics:rear-1", 90, 130);
   assert.equal(
-    moved.portSlots.find((slot) => slot.id === "six-nics-1")?.y,
+    moved.portSlots.find((slot) => slot.id === "six-nics:rear-1")?.x,
+    90,
+  );
+  assert.equal(
+    moved.portSlots.find((slot) => slot.id === "six-nics:rear-1")?.y,
     130,
   );
   assert.equal(template.portSlots.length, 0);

--- a/src/lib/hardware-template-builder.ts
+++ b/src/lib/hardware-template-builder.ts
@@ -107,25 +107,31 @@ function starter(
       : category === "storage"
         ? "sff"
         : "rj45";
-  const face: RackFace = category === "patch_panel" ? "front" : "rear";
+  const faces: RackFace[] =
+    category === "patch_panel" ? ["front", "rear"] : ["rear"];
   const blocks: PortBlockDefinition[] = [];
   if (portCount > 0) {
     const rows = portCount > 24 ? 2 : portCount > 12 ? 2 : 1;
-    blocks.push({
-      id: "ports",
-      face,
-      connector,
-      count: portCount,
-      rows,
-      columns: Math.ceil(portCount / rows),
-      start: 1,
-      direction: "left-to-right",
-      x: 110,
-      y: rows === 1 ? 108 : 80,
-      width: uplinkCount > 0 ? 650 : 780,
-      height: rows === 1 ? 62 : 126,
-      labelPrefix: category === "pdu" || category === "ups" ? "Outlet " : "",
-    });
+    for (const face of faces) {
+      blocks.push({
+        id:
+          category === "patch_panel"
+            ? faceQualifiedPortBlockId("ports", face)
+            : "ports",
+        face,
+        connector,
+        count: portCount,
+        rows,
+        columns: Math.ceil(portCount / rows),
+        start: 1,
+        direction: "left-to-right",
+        x: 110,
+        y: rows === 1 ? 108 : 80,
+        width: uplinkCount > 0 ? 650 : 780,
+        height: rows === 1 ? 62 : 126,
+        labelPrefix: category === "pdu" || category === "ups" ? "Outlet " : "",
+      });
+    }
   }
   if (uplinkCount > 0) {
     blocks.push({
@@ -450,19 +456,66 @@ export function replacePortBlock(
   template: HardwareTemplateV1,
   block: PortBlockDefinition,
 ): HardwareTemplateV1 {
-  const groupId = safeId(block.id);
+  const baseId = portBlockBaseId(block.id);
+  const groupId = faceQualifiedPortBlockId(baseId, block.face);
+  const normalizedBlock = { ...block, id: groupId };
+  const replacedBlueprints = template.portBlueprints.filter(
+    (entry) =>
+      portBlockBlueprintFace(entry) === block.face &&
+      portBlockBlueprintBaseId(entry) === baseId,
+  );
+  const replacedGroupIds = new Set([
+    baseId,
+    groupId,
+    ...replacedBlueprints
+      .map((entry) =>
+        typeof entry.id === "string" ? safeId(entry.id) : undefined,
+      )
+      .filter((id): id is string => Boolean(id)),
+  ]);
   const nextBlocks = [
-    ...template.portBlueprints.filter((entry) => entry.id !== block.id),
-    { ...block },
+    ...template.portBlueprints.filter(
+      (entry) =>
+        !(
+          portBlockBlueprintFace(entry) === block.face &&
+          portBlockBlueprintBaseId(entry) === baseId
+        ),
+    ),
+    normalizedBlock,
   ];
   return {
     ...template,
     portSlots: [
-      ...template.portSlots.filter((slot) => slot.groupId !== groupId),
-      ...generatePortBlock(block),
+      ...template.portSlots.filter(
+        (slot) =>
+          slot.face !== block.face ||
+          !(
+            (slot.groupId && replacedGroupIds.has(safeId(slot.groupId))) ||
+            (!slot.groupId && slot.id.startsWith(`${baseId}-`))
+          ),
+      ),
+      ...generatePortBlock(normalizedBlock),
     ],
     portBlueprints: nextBlocks,
   };
+}
+
+function portBlockBlueprintFace(entry: Record<string, unknown>) {
+  return entry.face === "front" || entry.face === "rear"
+    ? entry.face
+    : undefined;
+}
+
+function portBlockBlueprintBaseId(entry: Record<string, unknown>) {
+  return typeof entry.id === "string" ? portBlockBaseId(entry.id) : undefined;
+}
+
+function portBlockBaseId(id: string) {
+  return safeId(id).replace(/:(front|rear)$/, "");
+}
+
+function faceQualifiedPortBlockId(id: string, face: RackFace) {
+  return `${portBlockBaseId(id)}:${face}`;
 }
 
 export function movePhysicalPortSlot(

--- a/src/pages/visualizer/model.ts
+++ b/src/pages/visualizer/model.ts
@@ -2059,7 +2059,7 @@ function buildTraceAdjacency(model: VisualizerModel) {
       continue;
     const grouped = groupBy(
       model.portsByDeviceId[device.id] ?? [],
-      (port) => `${port.kind}:${port.name}`,
+      (port) => `${port.kind}:${port.name.trim().toLowerCase()}`,
     );
     for (const pair of Object.values(grouped)) {
       const front = pair.find((port) => port.face === "front");

--- a/src/pages/visualizer/trace-image.test.ts
+++ b/src/pages/visualizer/trace-image.test.ts
@@ -294,8 +294,11 @@ test("trace image groups a patch-panel pass-through into one device card", () =>
   ];
   const ports = [
     port("source_port", "source", "eth0"),
-    port("patch_front", "patch", "01", { face: "front" }),
-    port("patch_rear", "patch", "01", { face: "rear" }),
+    port("patch_front", "patch", "Jack 01", { face: "front", position: 1 }),
+    port("patch_rear", "patch", "  jack 01  ", {
+      face: "rear",
+      position: 99,
+    }),
     port("target_port", "target", "eth0"),
   ];
   const model = buildModel({
@@ -329,8 +332,8 @@ test("trace image groups a patch-panel pass-through into one device card", () =>
 
   const image = buildTraceImageSvg(model, result, labels, "light");
   assert.equal((image.svg.match(/>pp-01</g) ?? []).length, 1);
-  assert.match(image.svg, /01 \(Front\)/);
-  assert.match(image.svg, /01 \(Rear\)/);
+  assert.match(image.svg, /Jack 01 \(Front\)/);
+  assert.match(image.svg, /jack 01\s+\(Rear\)/);
   assert.match(image.svg, /Internal pass-through/);
   assert.match(image.svg, /3 hops · Length: 7m/);
   assert.ok(image.height > 800);


### PR DESCRIPTION
## Summary

- generate matching 24-port front and rear patch-panel starter blocks with face-qualified identities
- make authored block replacement face-aware while preserving stored templates and existing layout snapshots
- normalize patch-panel pass-through behavior for custom descendants and pair by normalized name plus kind
- show both starter faces, update builder wording and every locale, and publish beta.3 test notes

Closes no issue yet. Keep #148 and #139 open until Rack Studio testers confirm all four documented behaviors.

## Compatibility

- package version: `1.8.2-beta.3`
- schema remains 49
- no mass migration of saved templates or layout snapshots
- editing a legacy block upgrades only its selected face
- rollback to beta.2 needs no database restore

## Validation

- `npm run check:full` (276 server tests, 79 client tests, 34 Playwright tests)
- `npm run screenshots:check`
- `actionlint`
- Bash syntax and ShellCheck across `scripts` and `deploy/proxmox`
- development, release, and host-discovery Compose files render individually
- PowerShell syntax remains covered by hosted quality CI

Linked follow-up: #148
Original tester issue: #139