### PR TITLE
Prepare 1.8.3-beta.1 with strict CodeQL severity and Nodemailer security repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Rackpad uses semantic versioning and Git tags in the form `vX.Y.Z`.
 
 ## [Unreleased]
 
+## [1.8.3-beta.1] - 2026-09-09
+
+> Combined experimental candidate for stable `1.8.3` acceptance.
+> See the [candidate acceptance and upgrade notes](docs/releases/v1.8.3-beta.1.md).
+
+### Fixed
+
+- Reject malformed CodeQL severity values and missing scores on security-tagged
+  rules before applying reviewed exceptions. Preserve raw analysis on failure.
+- Update Nodemailer to 9.1.1 for its address-parser denial-of-service and related
+  security repairs, retaining the existing SMTP integration.
+
+### Changed
+
+- Retain the immutable beta.0 tag after canceling its publication before build
+  or release steps. Beta.1 carries the combined changes below; acceptance and soak
+  must use its exact published artifacts. All six tracked issues remain open.
+
 ## [1.8.3-beta.0] - 2026-09-08
 
 > Combined experimental candidate for stable `1.8.3` acceptance.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 Current stable release: `v1.8.0`
 
-Combined experimental beta candidate: `v1.8.3-beta.0`.
+Combined experimental beta candidate: `v1.8.3-beta.1`.
 Use [GitHub Releases](https://github.com/Kobii-git/rackpad/releases) to confirm
 the immutable tag and published artifacts before installation.
 
@@ -58,7 +58,7 @@ once the maintenance installer is published.
   pre-upgrade database/configuration snapshot, never an older image alone.
 
 See the [security upgrade notes](docs/releases/v1.8.2-beta.4-test-notes.md) and
-[combined schema-51 candidate notes](docs/releases/v1.8.3-beta.0.md).
+[combined schema-51 candidate notes](docs/releases/v1.8.3-beta.1.md).
 
 ### Maintenance installer preservation
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ monitoring, documentation, images, integrations, reports, labs, and
 administration into one clean app.
 
 Stable: **v1.8.0**.
-This branch prepares **v1.8.3-beta.0** for experimental testing.
+This branch prepares **v1.8.3-beta.1** for experimental testing.
 Use [GitHub Releases](https://github.com/Kobii-git/rackpad/releases) to confirm published artifacts.
-See the [combined candidate notes and acceptance checklist](docs/releases/v1.8.3-beta.0.md).
+See the [combined candidate notes and acceptance checklist](docs/releases/v1.8.3-beta.1.md).
 See the [changelog](./CHANGELOG.md); the latest-tag badge may show a prerelease.
 
 Built with:

--- a/docs/PROXMOX_LXC_ROADMAP.md
+++ b/docs/PROXMOX_LXC_ROADMAP.md
@@ -209,11 +209,13 @@ migration. The active [native guide](PROXMOX_NATIVE_LXC.md) and
 commands below; historical publication records remain unchanged. Beta.5 remains
 experimental while screenshot determinism and community acceptance are unresolved.
 
-The combined [v1.8.3-beta.0 candidate](releases/v1.8.3-beta.0.md) starts from
+The combined [v1.8.3-beta.1 candidate](releases/v1.8.3-beta.1.md) starts from
 published beta.5 and includes native startup readiness, mixed-face cable
 continuations, stacked switches, and SNMPv3 interoperability repairs. Schema 51 adds stack state; published
 migrations 49 and 50 remain unchanged. This candidate replaces the separate
-unpublished beta.6 and stack-development release plans.
+unpublished beta.6 and stack-development release plans. The beta.0 tag is retained;
+its publication was canceled before image/release steps after a malformed CodeQL
+severity check was found. Beta.1 repairs that gate and updates Nodemailer to 9.1.1.
 
 Community testers supply real Debian 13 and Ubuntu 24.04 PVE 9.x evidence,
 Rack Studio/patch-panel/stack acceptance, and a seven-day soak on the combined

--- a/docs/PROXMOX_NATIVE_LXC.md
+++ b/docs/PROXMOX_NATIVE_LXC.md
@@ -236,13 +236,13 @@ current installation exits without restarting the service. Failed activation
 restores the paired code, database, configuration, systemd assets, script
 origin, and Community core pin.
 
-The combined 1.8.3-beta.0 verifier allows up to 60 seconds for service/HTTP startup,
+The combined 1.8.3-beta.1 verifier allows up to 60 seconds for service/HTTP startup,
 with one-second retries and deadline-bounded HTTP/systemd calls. A failed or
 stopped service aborts early. Authentication, SPA, and collector checks run only
 after health succeeds. Fresh installation, candidate activation, rollback, and
 snapshot-failure recovery use the same wait; persistent failure retains the
 existing stop or paired-rollback behavior. See the
-[combined candidate acceptance checklist](releases/v1.8.3-beta.0.md).
+[combined candidate acceptance checklist](releases/v1.8.3-beta.1.md).
 
 ## Discovery privilege modes
 

--- a/docs/releases/v1.8.3-beta.1.md
+++ b/docs/releases/v1.8.3-beta.1.md
@@ -1,0 +1,121 @@
+# Rackpad v1.8.3-beta.1 combined candidate
+
+This candidate includes the maintenance, stabilization, stacked-switch, routing,
+patch-panel, Storage and SNMPv3 changes documented in the retained
+[beta.0 notes](v1.8.3-beta.0.md). Stable **1.8.3** requires community acceptance,
+seven consecutive days of soak, and final release checks. Docker remains the
+supported general deployment; native Proxmox LXC remains experimental.
+
+## Repairs since beta.0
+
+- CodeQL security severity must be a decimal string from 0 through 10. Arrays,
+  booleans, null, empty strings, numbers and out-of-range values fail validation
+  before suppression or exception handling. Security-tagged rules require a
+  score; ordinary unscored quality rules remain supported.
+- Nodemailer moves from 9.0.3 to 9.1.1, the compatible 9.x repair for the
+  [address-parser denial of service](https://github.com/advisories/GHSA-2x7j-588g-ccc2)
+  and [legacy content-resolution guard bypass](https://github.com/advisories/GHSA-8m3c-c648-2xjj).
+  SMTP settings and credential storage are unchanged.
+
+The beta.0 tag remains at `fb7fbcec511e2b95060055103a669cdbc894be3a`, the merge
+of PR #154. Its publication was canceled before build or release steps after
+independent review confirmed the severity-validation defect. No beta.0 GitHub
+release or versioned GHCR image was published. The tag must never be moved.
+
+## Reviewed CodeQL exceptions
+
+Only `js/insufficient-password-hash` at `server/lib/snmp-v3.ts` lines **83 and 90**
+is eligible, with one primary location confined to its identified line. Owner:
+**@Kobii-git**. Acceptance expires at **2026-11-30 00:00:00 UTC**; the exact
+boundary rejects the exception.
+
+- File SHA-256: `4029cff16fe59c2120322cf3340bc543564bd44f12835b57f20f27c2e35b3e63`
+- Git server tree: `29b7962b93a62fa05da1e4147afef36a68166827`
+
+[RFC 3414](https://www.rfc-editor.org/rfc/rfc3414.html) requires MD5/SHA password
+expansion and localization for interoperable SNMPv3 USM wire keys. These operations
+are not application login password storage. Existing credential encryption and
+configured MD5/SHA/AES128 interoperability remain intact.
+
+The shared policy requires unchanged tracked server content, no additional server
+files, valid Git/source evidence and an unambiguous analyzed source identity.
+Native reports without an absolute source-root mapping require embedded complete
+source matching the approved hash. Missing evidence disables acceptance. Dates
+and hashes are never renewed automatically.
+
+Raw SARIF is schema-validated and retained unchanged alongside an explicit review
+summary. Only accepted results are omitted from a separate upload report; all
+other findings, fingerprints, severities and analysis identities remain intact.
+Failed processing uploads raw analysis and blocks publication. Upload failure
+also blocks publication. No new broad suppression or alert dismissal is used.
+
+## Upgrade and recovery
+
+Schema remains **51**. Published migrations **49 and 50** and stack migration
+**51** are unchanged; security conversion remains at the schema-50 boundary.
+No new public API, environment variable or credential format is introduced.
+
+Before upgrade, retain the previous application plus its pre-upgrade database,
+configuration and original encryption key. Preserve `RACKPAD_SECRET_KEY` exactly.
+See the [security upgrade guidance](v1.8.2-beta.4-test-notes.md) for trusted proxy
+settings, OIDC role recovery and trap-source reconfiguration. Missing-key legacy
+conversion fails atomically; traps remain opt-in.
+
+Rollback restores that entire previous application/database/configuration/key
+pair. **Older binaries must never open schema-51 data.** A current logical backup
+cannot replace the pre-upgrade snapshot for downgrade. Test recovery only with
+disposable data and reject invalid ownership or newer-schema backups atomically.
+
+## Exact-candidate acceptance
+
+Use the [full guest and feature checklist](v1.8.3-beta.0.md#exact-candidate-acceptance-checklist)
+against **beta.1's immutable commit and published digests**, not beta.0 or a
+floating branch/tag. Record version, source commit, both architecture digests,
+source-asset hashes, platform/browser versions, UTC timestamps and results.
+
+| Issue | Required community evidence |
+| --- | --- |
+| #152 | Cisco IOS-XE SHA/AES in the reporter's Docker-network scenario: credential testing, monitoring, IF-MIB discovery, idle/engine-time recovery and rejection of wrong credentials. |
+| #153 | Firefox over ordinary LAN HTTP with fresh/upgraded Storage data: navigation, section creation/editing, saving and reload; record UUID availability and console errors. |
+| #138 | Disposable Debian 13 and Ubuntu 24.04 on PVE 9: install, schema 45/48/49/50 upgrades, reboot, custom ports, discovery modes, exact keys, recovery, injected failures and paired rollback. |
+| #139 | Rear/mixed-face continuations, selection, tracing, waypoints and exports. Brush-panel redesign remains outside this fix. |
+| #148 | Independent front/rear edits on a custom 24-column descendant: 48 bindings, zero unmapped ports, 24 pass-through pairs, tracing and persistence. |
+| #146 | Member metadata/order/MACs, nullable assignments, inherited types, derived height, unmount/undo/redo, loose-room moves, earlier history, genuine conflicts and preserved identities. |
+
+Include normal email alert delivery in beta.1 acceptance because Nodemailer is a
+runtime dependency change. Automated Net-SNMP and browser checks do not substitute
+for community Cisco, Firefox LAN HTTP or Proxmox guest evidence.
+
+After all acceptance criteria pass, record seven consecutive days of soak.
+Runtime, security, schema, dependency or OS-package changes require affected
+acceptance to repeat and soak to restart. Documentation/version-label changes
+alone do not. No community acceptance or soak is claimed by earlier CI results.
+All six issues stay open, including after publication. External Community Scripts
+listing remains separate from Rackpad's readiness for main.
+
+## Validation and publication
+
+Beta.0's final PR commit passed hosted application/browser, Firefox Storage,
+Net-SNMP, screenshot determinism, shell/workflow and CodeQL checks. Those results
+are historical evidence; beta.1 requires the full hosted pipeline again.
+
+Local beta.1 validation passed `npm run check`: 344 server tests, 92 client tests,
+51 configuration/publication/installer tests, 30 Proxmox fixture scenarios,
+documentation checks, lint/types, build and bundle limits. All 17 focused
+publication tests and actionlint passed. Independent review verified strict score
+strings, every driver/extension descriptor, and mandatory severity for the known
+SNMP rule even if its tags are missing; no actionable defect remained.
+Replaying both retained native hosted reports still accepted exactly lines 83/90
+with raw bytes and all retained metadata unchanged. A refreshed dependency audit
+reported zero vulnerabilities after the sole installed-package change to
+Nodemailer 9.1.1. Synthetic message/envelope validation passed without sending mail.
+
+Publication additionally requires refreshed scans and smoke tests of the actual
+published amd64 and arm64 digests, including authentication/denial, SPA/assets/fonts,
+logical/native restore and repeated schema-51 startup with disposable data.
+Fixable high/critical vulnerabilities and secret/configuration findings block;
+unfixed upstream OS advisories are documented without new broad suppressions.
+
+Integrate via the normal protected beta PR workflow and publish an immutable tag.
+Stable/main remains gated on acceptance, soak, final checks and resolved review
+conversations. Main publishes `latest`; no branch protection may be bypassed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rackpad",
-  "version": "1.8.3-beta.0",
+  "version": "1.8.3-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rackpad",
-      "version": "1.8.3-beta.0",
+      "version": "1.8.3-beta.1",
       "dependencies": {
         "@fastify/cors": "^10.0.1",
         "@fastify/rate-limit": "^11.1.0",
@@ -27,7 +27,7 @@
         "ipaddr.js": "^2.4.0",
         "lucide-react": "^0.468.0",
         "motion": "^11.15.0",
-        "nodemailer": "^9.0.3",
+        "nodemailer": "^9.1.1",
         "pino-pretty": "^13.1.1",
         "re2-wasm": "^1.0.2",
         "react": "^19.0.0",
@@ -5431,9 +5431,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
+      "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rackpad",
-  "version": "1.8.3-beta.0",
+  "version": "1.8.3-beta.1",
   "private": true,
   "type": "module",
   "engines": {
@@ -61,7 +61,7 @@
     "ipaddr.js": "^2.4.0",
     "lucide-react": "^0.468.0",
     "motion": "^11.15.0",
-    "nodemailer": "^9.0.3",
+    "nodemailer": "^9.1.1",
     "pino-pretty": "^13.1.1",
     "re2-wasm": "^1.0.2",
     "react": "^19.0.0",

--- a/scripts/check-codeql-results.mjs
+++ b/scripts/check-codeql-results.mjs
@@ -44,6 +44,22 @@ function resultRule(run, result) {
   return matches[0];
 }
 
+function securitySeverity(rule) {
+  const properties = rule.properties ?? {};
+  if (!Object.hasOwn(properties, "security-severity")) {
+    if (rule.id === SNMP_REVIEW.ruleId || properties.tags?.includes("security")) {
+      throw new Error("Missing CodeQL security severity");
+    }
+    return 0;
+  }
+  // CodeQL scores are decimal strings in [0, 10], not coercible SARIF property values.
+  const value = properties["security-severity"];
+  if (typeof value !== "string" || value.trim() !== value || !/^(?:[0-9](?:\.\d+)?|10(?:\.0+)?)$/.test(value)) {
+    throw new Error("Invalid CodeQL severity");
+  }
+  return Number(value);
+}
+
 export function reviewSarif(document, context, seen = new Set()) {
   if (document?.version !== "2.1.0" || !Array.isArray(document.runs) || !document.runs.length) {
     throw new Error("Missing or invalid CodeQL SARIF runs");
@@ -57,10 +73,12 @@ export function reviewSarif(document, context, seen = new Set()) {
     if (!Array.isArray(run.results) || run.invocations?.some((item) => item.executionSuccessful === false)) {
       throw new Error("Incomplete CodeQL analysis");
     }
+    for (const component of [run.tool.driver, ...(run.tool.extensions ?? [])]) {
+      for (const rule of component.rules ?? []) securitySeverity(rule);
+    }
     run.results = run.results.filter((result) => {
       const rule = resultRule(run, result);
-      const severity = Number(rule.properties?.["security-severity"] ?? 0);
-      if (!Number.isFinite(severity)) throw new Error("Invalid CodeQL severity");
+      const severity = securitySeverity(rule);
       const line = reviewedSnmpLocation(run, result, rule, context);
       if (line !== null) {
         const key = `${SNMP_REVIEW.file}:${line}`;

--- a/scripts/check-publication.test.mjs
+++ b/scripts/check-publication.test.mjs
@@ -23,6 +23,73 @@ test("CodeQL blocks high/critical findings and fails closed on missing analysis"
   assert.throws(() => inspectSarif(sarif("9.8", [{ ruleId: "unknown" }])));
 });
 
+test("CodeQL rejects malformed severity before suppressions or reviewed exceptions", () => {
+  for (const severity of [[], [8.1], {}, true, false, null, undefined, 0, 8.1, -1,
+    "", " ", " 8.1", "8.1 ", "8.1\n", "8.1\r", "8.1\u2028", "-1", "10.1", "10.0000000000000001", "Infinity", "NaN", "1e1", "0x8", "+8", ".8", "8.", "08"]) {
+    assert.throws(() => inspectSarif(sarif(severity)), /CodeQL severity/);
+    assert.throws(() => inspectSarif(sarif(severity, [
+      { ruleId: "test-rule", suppressions: [{ kind: "external", status: "accepted" }] },
+    ])), /CodeQL severity/);
+    const document = snmpSarif();
+    document.runs[0].tool.extensions[1].rules[0].properties["security-severity"] = severity;
+    assert.throws(() => reviewSarif(document, reviewedContext()), /CodeQL severity/);
+  }
+  for (const [severity, failures] of [["0", 0], ["0.0", 0], ["5", 0], ["6.9", 0], ["7", 1], ["8.1", 1], ["10", 1], ["10.0", 1]]) {
+    assert.equal(inspectSarif(sarif(severity)), failures);
+  }
+});
+
+test("only non-security rules may omit severity metadata", () => {
+  const document = sarif("5");
+  const rule = document.runs[0].tool.driver.rules[0];
+  delete rule.properties["security-severity"];
+  assert.equal(inspectSarif(document), 0);
+  rule.properties.tags = ["maintainability"];
+  assert.equal(inspectSarif(document), 0);
+  rule.properties.tags.push("security");
+  assert.throws(() => inspectSarif(document), /Missing CodeQL security severity/);
+  delete rule.properties;
+  assert.equal(inspectSarif(document), 0);
+  const snmp = snmpSarif();
+  snmp.runs[0].tool.extensions[1].rules[0].properties = { tags: ["security"] };
+  assert.throws(() => reviewSarif(snmp, reviewedContext()), /Missing CodeQL security severity/);
+  delete snmp.runs[0].tool.extensions[1].rules[0].properties;
+  for (const context of [reviewedContext(), { ...reviewedContext(), clean: false },
+    { ...reviewedContext(), now: Date.parse(SNMP_REVIEW.expiresAt) }]) {
+    assert.throws(() => reviewSarif(snmp, context), /Missing CodeQL security severity/);
+  }
+});
+
+test("unused driver and extension descriptors also require valid security metadata", () => {
+  for (const location of ["driver", "extension"]) {
+    for (const properties of [{ "security-severity": [] }, { tags: ["security"] }]) {
+      const document = snmpSarif();
+      const component = location === "driver" ? document.runs[0].tool.driver : document.runs[0].tool.extensions[0];
+      component.rules = [{ id: "unreferenced-rule", properties }];
+      assert.throws(() => reviewSarif(document, reviewedContext()), /CodeQL (?:security )?severity/);
+      component.rules[0].properties = { tags: ["maintainability"] };
+      assert.equal(reviewSarif(document, reviewedContext()).reviewed.length, 2);
+    }
+  }
+});
+
+test("malformed severity leaves raw evidence intact and preparation blocked", (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), "rackpad-codeql-severity-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const input = path.join(root, "raw");
+  mkdirSync(input);
+  const file = path.join(input, "report.sarif");
+  const original = JSON.stringify(sarif([]), null, 2);
+  writeFileSync(file, original);
+  let output;
+  assert.throws(() => prepareCodeqlReports(input, path.join(root, "review"), {
+    root, onDirectory(directory) { output = directory; },
+  }), /Invalid CodeQL severity/);
+  assert.equal(readFileSync(file, "utf8"), original);
+  assert.equal(JSON.parse(readFileSync(path.join(output, "review-summary.json"))).status, "blocked");
+  assert.equal(existsSync(path.join(output, "prepared")), false);
+});
+
 test("CodeQL resolves extension-local rule metadata and rejects ambiguous references", () => {
   // Matches CodeQL 4.37.9's hosted SARIF shape: metadata lives in an extension.
   const document = sarif("1.0", [{ ruleId: "test-rule", rule: { id: "test-rule", index: 0, toolComponent: { index: 1 } } }]);


### PR DESCRIPTION
Malformed CodeQL severity properties could be coerced to zero, allowing invalid analysis to pass the publication gate. This candidate requires decimal string scores from 0 through 10, validates every driver/extension descriptor, and requires a score for security-tagged rules and the known SNMP rule even when its tags are missing. Valid integer strings and unscored non-security rules remain supported.

The exact exceptions for SNMP lines 83/90, their file/server hashes, owner and expiry remain unchanged. Raw SARIF and failure summaries are preserved; no workflow suppression, runtime source, API, schema or credential-format change is introduced.

The refreshed audit also identified a fixable high-severity Nodemailer advisory. Update only that installed dependency from 9.0.3 to patched 9.1.1, retaining the existing SMTP integration. Package and lockfile versions are updated through npm to `1.8.3-beta.1`; current release/upgrade notes point to the new candidate.

The immutable beta.0 tag remains at `fb7fbcec511e2b95060055103a669cdbc894be3a`. Both beta.0 publication runs were canceled before any build/release steps; no beta.0 release or versioned image was published. This PR supersedes that publication attempt without replacing its tag or historical evidence.

Validation executed locally:

- `npm run check`: 344 server, 92 client, 51 configuration/publication/installer tests, 30 Proxmox fixture scenarios, documentation, lint/types, build and bundle checks passed.
- All 17 publication regressions and actionlint passed; final configuration, documentation and lint checks refreshed after review.
- Both retained native hosted SARIF reports still produce exactly two exceptions. Raw bytes and every retained result/metadata field are unchanged.
- `npm audit`: zero vulnerabilities after Nodemailer 9.1.1. Synthetic message/envelope check passed without sending mail.
- Independent targeted review found no remaining actionable severity-gate defect.

Hosted filesystem/image scans, both PR CodeQL jobs and GitHub's separate CodeQL check passed on `947aca1`. PR analysis is limited to changed lines, so a separate [full-source CodeQL run](https://github.com/Kobii-git/rackpad/actions/runs/34292221319) was executed on the same commit: its native raw SARIF contains exactly two results, both accepted at lines 83/90. Raw SHA-256: `8b217b728b93a0c691b1ffa47bc936f6d49a6c0a6ca09c827f3feb097bfef994`. Replay preserved raw bytes and all retained metadata; an added synthetic unrelated critical finding still blocks, and exact expiry blocks both SNMP findings.

Both locally rebuilt architectures passed authentication/denial, SPA/assets/fonts, logical/native restore and repeat schema-51 startup. Local scans found zero fixable high/critical or secret/configuration findings and 54 unfixed upstream OS advisories per architecture. The complete [hosted PR pipeline](https://github.com/Kobii-git/rackpad/actions/runs/34291860366) passed on `947aca1`, including both-architecture build, all 42 Chromium tests, 12 Storage browser cases, four Net-SNMP security combinations, screenshot determinism, Bash/ShellCheck/PowerShell and workflow checks. Publication and actual published amd64/arm64 digest validation remain required. Nodemailer is a runtime dependency change: community acceptance, including normal email alerts, must use beta.1. Main/stable waits for all acceptance evidence plus seven consecutive days of soak. Keep issues #138, #139, #146, #148, #152 and #153 open. Preserve all existing worktrees and unrelated PRs.
